### PR TITLE
Enable manual and pull request triggers in GitHub Actions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -26,7 +26,7 @@ runs:
   steps:
     - name: Get PHP extension cache hash
       id: get-cache-hash
-      with:
+      env:
         PHP_EXTENSIONS: ${{ inputs.php-extensions }}
       run: echo hash=$(echo $PHP_EXTENSIONS | md5sum) >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
       - dev*
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+      - integration
 
 jobs:
   tests:


### PR DESCRIPTION
Added workflow_dispatch for manual runs and pull_request for specific branches (main and integration). This ensures greater flexibility and control over triggering workflows.